### PR TITLE
Feature/extended property access

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,16 @@ der NAPI aus. Diese Objekte haben eine ID, einen Typ und Relationen zu anderen R
 Alle `AbstractModels` sind fast auschließlich Unterobjekte einer Resource und gliedern die teilweise komplexen Daten
 der Resourcen-Objekte.
 
+### Attribute
+
+In der Regel kann mit den jeweiligen `get*()`-Methoden auf die Eigenschaften einer Resource zugegriffen werden.
+
+Die dynamische Verarbeitung von Objekten, die mit `method_exists()` prüft, ob ein Attribute holbar ist, ist allerdings
+nicht möglich, da einige `get*()`-Methoden magisch sind. 
+Um trotzdem eine dynamische Prüfung und Verarbeitung von Attributen zu ermöglichen, kann mit `property_exists()` und
+dem direkten Zugriff auf die Property via `$object->property` gearbeitet werden. Dabei werden Features wie
+`ResourcePlaceholder` und `ResolutionProxy` aus den folgenden Abschnitten berücksichtigt.
+
 ### Includes
 
 Die NAPI selbst basiert auf der [JSON API 1.0 Spezifikation](http://jsonapi.org/) und arbeitet deshalb mit der Option,

--- a/tests/Domain/Model/PropertyAccessTest.php
+++ b/tests/Domain/Model/PropertyAccessTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nordkirche\Ndk\Domain\Model;
+
+use Nordkirche\Ndk\Helper\MockModel;
+use Nordkirche\Ndk\Helper\MockSiblingModel;
+use PHPUnit\Framework\TestCase;
+
+class PropertyAccessTest extends TestCase
+{
+
+    /**
+     * @group unit
+     */
+    public function testAccessProtectedPropertyAsPublic()
+    {
+        $modelSibling = new MockSiblingModel();
+
+        $model = new MockModel();
+        $model->setObject($modelSibling);
+
+        self::assertEquals($modelSibling, $model->getObject());
+        self::assertEquals($modelSibling, $model->object);
+    }
+}

--- a/tests/Helper/MockModel.php
+++ b/tests/Helper/MockModel.php
@@ -9,6 +9,7 @@ use Nordkirche\Ndk\Service\Result;
 
 /**
  * @method MockSiblingModel getObject()
+ * @property MockSiblingModel object
  */
 class MockModel extends AbstractResourceObject
 {

--- a/tests/Helper/MockModel.php
+++ b/tests/Helper/MockModel.php
@@ -1,8 +1,11 @@
 <?php
 
-namespace Nordkirche\Ndk\Service;
+namespace Nordkirche\Ndk\Helper;
 
 use Nordkirche\Ndk\Domain\Model\AbstractResourceObject;
+use Nordkirche\Ndk\Service\MissingResourceProxy;
+use Nordkirche\Ndk\Service\ResolutionProxy;
+use Nordkirche\Ndk\Service\Result;
 
 /**
  * @method MockSiblingModel getObject()
@@ -114,7 +117,7 @@ class MockModel extends AbstractResourceObject
 
     /**
      * @param Result $resultObject
-     * @subtype \Nordkirche\Ndk\Service\MockSiblingModel
+     * @subtype \Nordkirche\Ndk\Helper\MockSiblingModel
      */
     public function setResultObject(Result $resultObject)
     {

--- a/tests/Helper/MockResourceObject.php
+++ b/tests/Helper/MockResourceObject.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nordkirche\Ndk\Service;
+namespace Nordkirche\Ndk\Helper;
 
 class MockResourceObject implements \Nordkirche\Ndk\Service\Interfaces\ResourceObjectInterface
 {

--- a/tests/Helper/MockSiblingModel.php
+++ b/tests/Helper/MockSiblingModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nordkirche\Ndk\Service;
+namespace Nordkirche\Ndk\Helper;
 
 class MockSiblingModel extends \Nordkirche\Ndk\Domain\Model\AbstractResourceObject
 {

--- a/tests/Service/ModelDecoratorServiceTest.php
+++ b/tests/Service/ModelDecoratorServiceTest.php
@@ -2,7 +2,8 @@
 
 namespace Nordkirche\Ndk\Service;
 
-use Nordkirche\Ndk\Service\ModelDecoratorService;
+use Nordkirche\Ndk\Helper\MockModel;
+use Nordkirche\Ndk\Helper\MockSiblingModel;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class ModelDecoratorServiceTest extends \Nordkirche\Ndk\Helper\AbstractIntegrationTestCase

--- a/tests/Service/NapiServiceTest.php
+++ b/tests/Service/NapiServiceTest.php
@@ -6,6 +6,7 @@ use Nordkirche\Ndk\Api;
 use Nordkirche\Ndk\Configuration;
 use Nordkirche\Ndk\Helper\SetupApiTrait;
 use PHPUnit\Framework\TestCase;
+use Nordkirche\Ndk\Helper\MockResourceObject;
 
 class NapiServiceTest extends TestCase
 {
@@ -148,7 +149,7 @@ class NapiServiceTest extends TestCase
     {
         $this->setUpIntegration();
         $configuration = Api::$api->getConfiguration()->setTypeClassMap([
-            'sometype' => \Nordkirche\Ndk\Service\MockModel::class
+            'sometype' => \Nordkirche\Ndk\Helper\MockModel::class
         ]);
         $resolutionService = Api::$api->factory()->get(ResolutionService::class);
 

--- a/tests/Service/ResolutionServiceTest.php
+++ b/tests/Service/ResolutionServiceTest.php
@@ -4,6 +4,8 @@ namespace Nordkirche\Ndk\Service;
 
 use Monolog\Logger;
 use Nordkirche\Ndk\Helper\AbstractIntegrationTestCase;
+use Nordkirche\Ndk\Helper\MockModel;
+use Nordkirche\Ndk\Helper\MockSiblingModel;
 
 class ResolutionServiceTest extends AbstractIntegrationTestCase
 {
@@ -276,8 +278,8 @@ class ResolutionServiceTest extends AbstractIntegrationTestCase
     {
         parent::setUp();
         $this->api->getConfiguration()->setTypeClassMap([
-            'mock-model-type' => \Nordkirche\Ndk\Service\MockModel::class,
-            'mock-model-sibling-type' => \Nordkirche\Ndk\Service\MockSiblingModel::class
+            'mock-model-type' => \Nordkirche\Ndk\Helper\MockModel::class,
+            'mock-model-sibling-type' => \Nordkirche\Ndk\Helper\MockSiblingModel::class
         ]);
         $this->resolutionService = $this->api->factory(ResolutionService::class);
     }

--- a/tests/Service/ResultTest.php
+++ b/tests/Service/ResultTest.php
@@ -3,6 +3,7 @@
 namespace Nordkirche\Ndk\Service;
 
 use PHPUnit\Framework\TestCase;
+use Nordkirche\Ndk\Helper\MockModel;
 
 class ResultTest extends TestCase
 {


### PR DESCRIPTION
Allow ready only access to private properties via magic getters as an alternative to `get*()` methods 